### PR TITLE
Forward-port Github changes to 2.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -873,6 +873,13 @@ We recommend sticking this in your initializer somewhere after Redis
 is configured.
 
 
+Worker Role
+-----------
+
+Setting `Resque.worker_role` will add the given string to the worker's hostname
+separated with a `/`.
+
+
 Demo
 ----
 

--- a/README.markdown
+++ b/README.markdown
@@ -370,6 +370,13 @@ And workers on our specialized archive machine with this command:
 
     $ QUEUE=archive rake resque:work
 
+#### Blocking and Non-blocking Pop
+
+Resque allows you to configure `Resque.blocking_reserve = true` to alter the way
+jobs are selected from queues. By default Resque will use Redis::Namespace `lpop`
+to pull jobs from the queue. After setting `blocking_reserve` to `true` Resque
+will use `blpop` for all jobs.
+
 
 ### Running All Queues
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -73,6 +73,9 @@ The available hooks are:
 * `before_enqueue`: Called with the job args before a job is placed on the queue.
   If the hook returns `false`, the job will not be placed on the queue.
 
+* `before_push`: Called with the job to be pushed onto the queue when using
+  `Resque.create(...)`.
+
 * `after_enqueue`: Called with the job args after a job is placed on the queue.
   Any exception raised propagates up to the code which queued the job.
 
@@ -95,8 +98,17 @@ The available hooks are:
   thrown by `perform`, but any that are not caught will propagate up to the
   `Resque::Failure` backend.
 
+* `after_perform`: Called with the job after a job is done working. This could
+  be used to decide when to shut down workers that consume too much RAM, for example.
+
 * `on_failure`: Called with the exception and job args if any exception occurs
   while performing the job (or hooks), this includes Resque::DirtyExit.
+
+* `before_reserve`: Called with the reserved queue. This hook is used to
+  determine which `reservable_queues` should be checked for work. The block will
+  be called once for each of the worker's assigned queues; raising
+  `Resque::DontReserve` will skip that queue. Only run when
+  `Resque.blocking_reserve` is `true`.
 
 Hooks are easily implemented with superclasses or modules. A superclass could
 look something like this.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -107,8 +107,7 @@ The available hooks are:
 * `before_reserve`: Called with the reserved queue. This hook is used to
   determine which `reservable_queues` should be checked for work. The block will
   be called once for each of the worker's assigned queues; raising
-  `Resque::DontReserve` will skip that queue. Only run when
-  `Resque.blocking_reserve` is `true`.
+  `Resque::DontReserve` will skip that queue.
 
 Hooks are easily implemented with superclasses or modules. A superclass could
 look something like this.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -96,7 +96,8 @@ The available hooks are:
 * `around_perform`: Called with the job args. It is expected to yield in order
   to perform the job (but is not required to do so). It may handle exceptions
   thrown by `perform`, but any that are not caught will propagate up to the
-  `Resque::Failure` backend.
+  `Resque::Failure` backend. If the callback method's name ends with `_with_job`,
+  the complete `Resque::Job` object will be passed, rather than the job's arguments.
 
 * `after_perform`: Called with the job after a job is done working. This could
   be used to decide when to shut down workers that consume too much RAM, for example.
@@ -108,6 +109,9 @@ The available hooks are:
   determine which `reservable_queues` should be checked for work. The block will
   be called once for each of the worker's assigned queues; raising
   `Resque::DontReserve` will skip that queue.
+
+* `queue_name_prefix`: called with the queue name when enqueuing a job. The return
+value will become the new destination. This option defaults to the identity function.
 
 Hooks are easily implemented with superclasses or modules. A superclass could
 look something like this.

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -246,6 +246,15 @@ module Resque
     end
   end
 
+  attr_writer :blocking_reserve
+  def blocking_reserve
+    if defined? @blocking_reserve
+      @blocking_reserve
+    else
+      @blocking_reserve = false
+    end
+  end
+
   attr_writer :queue_name_prefix
   def queue_name_prefix(&block)
     if block

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -264,6 +264,8 @@ module Resque
     end
   end
 
+  # This block will receive the queue name passed to `enqueue_to`. Its return
+  # value will be the actual queue name. Defaults to the identity function.
   attr_writer :queue_name_prefix
   def queue_name_prefix(&block)
     if block

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -219,6 +219,24 @@ module Resque
     end
   end
 
+  attr_writer :per_worker_stats
+  def per_worker_stats
+    if defined? @per_worker_stats
+      @per_worker_stats
+    else
+      @per_worker_stats = true
+    end
+  end
+
+  attr_writer :track_starts
+  def track_starts
+    if defined? @track_starts
+      @track_starts
+    else
+      @track_starts = true
+    end
+  end
+
   # The `before_first_fork` hook will be run in the **parent** process
   # only once, before forking to run the first job. Be careful- any
   # changes you make will be permanent for the lifespan of the

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -219,6 +219,7 @@ module Resque
     end
   end
 
+  # Setting `per_worker_stats = false` opts *out* of tracking these statistics.
   attr_writer :per_worker_stats
   def per_worker_stats
     if defined? @per_worker_stats
@@ -228,6 +229,7 @@ module Resque
     end
   end
 
+  # Setting `track_starts = false` opts *out* of tracking these statistics.
   attr_writer :track_starts
   def track_starts
     if defined? @track_starts
@@ -237,6 +239,10 @@ module Resque
     end
   end
 
+  # Standard Resque workers store the list of queues they're listening to in
+  # their name; this can cause Redis performance issues with long queue lists.
+  # Setting `Resque.queues_in_names = false` makes workers keep the list in a
+  # separate Redis entry.
   attr_writer :queues_in_names
   def queues_in_names
     if defined? @queues_in_names
@@ -246,6 +252,9 @@ module Resque
     end
   end
 
+  # By default jobs are selected from the queue using `pop`. Setting this
+  # attribute to `true` well set all queues to use the blocking version `blpop`
+  # from Redis.
   attr_writer :blocking_reserve
   def blocking_reserve
     if defined? @blocking_reserve

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -246,6 +246,8 @@ module Resque
     end
   end
 
+  attr_accessor :worker_role
+
   # The `before_first_fork` hook will be run in the **parent** process
   # only once, before forking to run the first job. Be careful- any
   # changes you make will be permanent for the lifespan of the

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -343,6 +343,14 @@ module Resque
     register_hook(:after_perform, block)
   end
 
+  def before_push(&block)
+    block ? register_hook(:before_push, block) : hooks(:before_push)
+  end
+
+  def before_push=(block)
+    register_hook(:before_push, block)
+  end
+
   def to_s
     "Resque Client connected to #{redis_id}"
   end

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -237,6 +237,15 @@ module Resque
     end
   end
 
+  attr_writer :queues_in_names
+  def queues_in_names
+    if defined? @queues_in_names
+      @queues_in_names
+    else
+      @queues_in_names = true
+    end
+  end
+
   # The `before_first_fork` hook will be run in the **parent** process
   # only once, before forking to run the first job. Be careful- any
   # changes you make will be permanent for the lifespan of the

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -314,6 +314,22 @@ module Resque
     register_hook(:after_pause, block)
   end
 
+  def before_reserve(&block)
+    block ? register_hook(:before_reserve, block) : hooks(:before_reserve)
+  end
+
+  def before_reserve=(block)
+    register_hook(:before_reserve, block)
+  end
+
+  def after_perform(&block)
+    block ? register_hook(:after_perform, block) : hooks(:after_perform)
+  end
+
+  def after_perform=(block)
+    register_hook(:after_perform, block)
+  end
+
   def to_s
     "Resque Client connected to #{redis_id}"
   end
@@ -353,6 +369,11 @@ module Resque
   # Returns a Ruby object.
   def pop(queue)
     decode(data_store.pop_from_queue(queue))
+  end
+
+  def blocking_pop(queues, interval)
+    queue, payload = data_store.blocking_pop(queues, interval)
+    queue && [queue, decode(payload)]
   end
 
   # Returns an integer representing the size of a queue.

--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -211,12 +211,6 @@ module Resque
     end
 
     class Workers
-      class << self
-        attr_accessor :track_starts
-      end
-
-      self.track_starts = true
-
       def initialize(redis)
         @redis = redis
       end
@@ -249,7 +243,7 @@ module Resque
       end
 
       def worker_started(worker)
-        if self.class.track_starts
+        if track_starts
           @redis.set(redis_key_for_worker_start_time(worker), Time.now.to_s)
         end
       end
@@ -258,7 +252,7 @@ module Resque
         @redis.pipelined do
           @redis.srem(:workers, worker)
           @redis.del(redis_key_for_worker(worker))
-          if self.class.track_starts
+          if track_starts
             @redis.del(redis_key_for_worker_start_time(worker))
           end
           @redis.hdel(HEARTBEAT_KEY, worker.to_s)
@@ -315,6 +309,10 @@ module Resque
 
       def redis_key_for_worker_pruning
         "pruning_dead_workers_in_progress"
+      end
+
+      def track_starts
+        Resque.track_starts
       end
     end
 

--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -257,7 +257,7 @@ module Resque
         @redis.pipelined do
           @redis.sadd(:workers, worker)
           unless queues_in_names
-            @redis.set("worker:#{worker}:queues", worker.queues.join(","))
+            @redis.set("worker:#{worker}:queues", worker.assigned_queues.join(","))
           end
           worker_started(worker)
         end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -48,7 +48,7 @@ module Resque
     def self.decode(object)
       Resque.decode(object)
     end
-    
+
     # Given a word with dashes, returns a camel cased version of it.
     def classify(dashed_word)
       Resque.classify(dashed_word)
@@ -62,6 +62,10 @@ module Resque
     # Raise Resque::Job::DontPerform from a before_perform hook to
     # abort the job.
     DontPerform = Class.new(StandardError)
+
+    # Raise Resque::Job::DontReserve from a before_reserve hook to
+    # stop the worker from taking a job from the queue.
+    DontReserve = Class.new(StandardError)
 
     # The worker object which is currently processing this job.
     attr_accessor :worker
@@ -142,6 +146,12 @@ module Resque
     def self.reserve(queue)
       return unless payload = Resque.pop(queue)
       new(queue, payload)
+    end
+
+    def self.blocking_reserve(queues, interval)
+      return if queues.empty?
+      queue, payload = Resque.blocking_pop(queues, interval)
+      payload && new(queue, payload)
     end
 
     # Attempts to perform the work represented by this job instance.

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -286,6 +286,9 @@ module Resque
 
     def failure_hooks
       @failure_hooks ||= Plugin.failure_hooks(payload_class)
+    rescue NameError
+      # if the payload class doesn't exist, there are no hooks
+      []
     end
 
     def run_failure_hooks(exception)

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -96,7 +96,7 @@ module Resque
         # decode(encode(args)) to ensure that args are normalized in the same manner as a non-inline job
         new(:inline, {'class' => klass, 'args' => decode(encode(args))}).perform
       else
-        job = new(queue, {'class' => klass, 'args' => decode(encode(args))})
+        job = new(queue, {'class' => klass.to_s, 'args' => decode(encode(args))})
         job.queued_at = Time.now
         Resque.before_push.each do |hook|
           hook.call(job)

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -355,7 +355,6 @@ module Resque
     #
     # Blocks for up to `interval` seconds.
     def blocking_reserve(interval)
-      # TODO: why is reservable_queues on Job?
       available_queues = reservable_queues
       if available_queues.empty?
         sleep interval # prevent busy-wait.

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -404,7 +404,7 @@ module Resque
       register_signal_handlers
       start_heartbeat
       prune_dead_workers
-      run_hook :before_first_fork
+      run_hook :before_first_fork, self
       register_worker
 
       # Fix buffering so we can `rake resque:work > resque.log` and

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -647,7 +647,7 @@ module Resque
       our_queues = queues.to_set
 
       unless all_workers.empty?
-        known_workers = worker_pids
+        known_workers = worker_pids.map(&:to_i)
         all_workers_with_expired_heartbeats = Worker.all_workers_with_expired_heartbeats
       end
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -719,27 +719,14 @@ module Resque
       Stat["processed:#{self}"]
     end
 
-    def self.per_worker_stats
-      return @per_worker_stats if defined?(@per_worker_stats)
-      @per_worker_stats = true
-    end
-
-    def self.per_worker_stats=(v)
-      @per_worker_stats = v
-    end
-
-    def self.track_starts
-      DataStore::Workers.track_starts
-    end
-
-    def self.track_starts=(v)
-      DataStore::Workers.track_starts = v
+    def per_worker_stats
+      Resque.per_worker_stats
     end
 
     # Tell Redis we've processed a job.
     def processed!
       Stat << "processed"
-      if self.class.per_worker_stats
+      if per_worker_stats
         Stat << "processed:#{self}"
       end
     end
@@ -752,7 +739,7 @@ module Resque
     # Tells Redis we've failed a job.
     def failed!
       Stat << "failed"
-      if self.class.per_worker_stats
+      if per_worker_stats
         Stat << "failed:#{self}"
       end
     end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -719,10 +719,29 @@ module Resque
       Stat["processed:#{self}"]
     end
 
+    def self.per_worker_stats
+      return @per_worker_stats if defined?(@per_worker_stats)
+      @per_worker_stats = true
+    end
+
+    def self.per_worker_stats=(v)
+      @per_worker_stats = v
+    end
+
+    def self.track_starts
+      DataStore::Workers.track_starts
+    end
+
+    def self.track_starts=(v)
+      DataStore::Workers.track_starts = v
+    end
+
     # Tell Redis we've processed a job.
     def processed!
       Stat << "processed"
-      Stat << "processed:#{self}"
+      if self.class.per_worker_stats
+        Stat << "processed:#{self}"
+      end
     end
 
     # How many failed jobs has this worker seen? Returns an int.
@@ -733,7 +752,9 @@ module Resque
     # Tells Redis we've failed a job.
     def failed!
       Stat << "failed"
-      Stat << "failed:#{self}"
+      if self.class.per_worker_stats
+        Stat << "failed:#{self}"
+      end
     end
 
     # What time did this worker start? Returns an instance of `Time`

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -221,6 +221,11 @@ module Resque
       end
     end
 
+    # Returns a list of queues assigned to this worker. Does not expand wildcards.
+    def assigned_queues
+      @queues
+    end
+
     def glob_match(list, pattern)
       list.select do |queue|
         File.fnmatch?(pattern, queue)

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -1,5 +1,4 @@
-$LOAD_PATH.unshift 'lib'
-require 'resque/version'
+require File.expand_path("../lib/resque/version", __FILE__)
 
 Gem::Specification.new do |s|
   s.name              = "resque"

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -111,6 +111,24 @@ describe "Resque::Job around_perform" do
     assert_equal history, [:start_around_perform, :perform, :finish_around_perform]
   end
 
+  class ::AroundPerformWithJob
+    def self.perform(history)
+      history << :perform
+    end
+    def self.around_perform_record_history_with_job(job)
+      history = job.args.first
+      history << :start_around_perform
+      yield
+      history << :finish_around_perform
+    end
+  end
+
+  it "it runs around_perform, passing the job, then yields in order to perform" do
+    result = perform_job(AroundPerformWithJob, history=[])
+    assert_equal true, result, "perform returned true"
+    assert_equal history, [:start_around_perform, :perform, :finish_around_perform]
+  end
+
   class ::AroundPerformJobFailsBeforePerforming
     def self.perform(history)
       history << :perform

--- a/test/resque_hook_test.rb
+++ b/test/resque_hook_test.rb
@@ -13,6 +13,13 @@ describe "Resque Hooks" do
     @worker = Resque::Worker.new(:jobs)
   end
 
+  after do
+    Resque.before_first_fork = nil
+    Resque.before_fork = nil
+    Resque.after_fork = nil
+    Resque.before_push = nil
+  end
+
   it 'retrieving hooks if none have been set' do
     assert_equal [], Resque.before_first_fork
     assert_equal [], Resque.before_fork
@@ -91,6 +98,18 @@ describe "Resque Hooks" do
 
     Resque::Job.create(:jobs, CallNotifyJob)
     @worker.work(0)
+  end
+
+  it 'calls before_push callbacks with the job' do
+    job = nil
+
+    Resque.before_push { |j| job = j }
+
+    Resque::Job.create(:jobs, CallNotifyJob)
+    @worker.work(0)
+
+    assert job
+    assert job.queued_at
   end
 
   it 'it registers multiple before_first_forks' do

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -177,6 +177,24 @@ describe "Resque" do
     end
   end
 
+  it "prefixes queues" do
+    begin
+      old_prefix = Resque.queue_name_prefix
+      Resque.queue_name_prefix do |base_name|
+        "prefix_#{base_name}"
+      end
+      Resque.enqueue_to(:new_queue, SomeMethodJob, 20, '/tmp')
+
+      job = Resque.reserve(:prefix_new_queue)
+
+      assert_equal SomeMethodJob, job.payload_class
+      assert_equal 20, job.args[0]
+      assert_equal '/tmp', job.args[1]
+    ensure
+      Resque.queue_name_prefix = old_prefix
+    end
+  end
+
   it "decode bad json" do
     assert_raises Resque::Helpers::DecodeException do
       Resque.decode("{\"error\":\"Module not found \\u002\"}")

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -218,6 +218,13 @@ describe "Resque" do
       assert_equal 0, Resque.size(:people)
     end
 
+    it "can pull items off a queue" do
+      assert_equal(["people", { 'name' => 'chris' }], Resque.blocking_pop(:people, 1.0))
+      assert_equal(["people", { 'name' => 'bob' }], Resque.blocking_pop(:people, 1.0))
+      assert_equal(["people", { 'name' => 'mark' }], Resque.blocking_pop(:people, 1.0))
+      assert_nil Resque.pop(:people)
+    end
+
     it "can peek at a queue" do
       assert_equal({ 'name' => 'chris' }, Resque.peek(:people))
       assert_equal 3, Resque.size(:people)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,6 +75,10 @@ else
   Resque.redis = 'localhost:9736'
 end
 
+if ENV.key?('RESQUE_BLOCKING_RESERVE')
+  Resque.blocking_reserve = true
+end
+
 ##
 # Helper to perform job classes
 #

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -466,7 +466,7 @@ describe "Resque::Worker" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         task = @worker.job
-        assert_equal({"args"=>[20, "/tmp"], "class"=>"SomeJob"}, task['payload'])
+        assert_equal({"args"=>[20, "/tmp"], "class"=>"SomeJob"}, task['payload'].slice("args", "class"))
         assert task['run_at']
         assert_equal 'jobs', task['queue']
       end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -1122,6 +1122,16 @@ describe "Resque::Worker" do
     assert_equal 1, Resque::Failure.count
   end
 
+  it "before_reserve hook can stop a worker from pulling from queue" do
+    Resque.before_reserve do |queue|
+      raise Resque::Job::DontReserve if queue == "jobs"
+    end
+    worker = Resque::Worker.new(:jobs, :more_jobs)
+    worker.work(0)
+    assert_equal 1, Resque.size(:jobs)
+    Resque.before_reserve = nil
+  end
+
   it "no reconnects to redis when not forking" do
     original_connection = Resque.redis._client.connection.instance_variable_get("@sock")
     without_forking do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -536,7 +536,7 @@ describe "Resque::Worker" do
   end
 
   it "does not track per-worker stats when turned off" do
-    Resque::Worker.per_worker_stats = false
+    Resque.per_worker_stats = false
     Resque::Job.create(:jobs, BadJob)
     Resque::Job.create(:jobs, BadJob)
 
@@ -549,7 +549,7 @@ describe "Resque::Worker" do
     assert_equal 3, Resque::Stat["processed"]
     assert_equal 2, Resque::Stat["failed"]
 
-    Resque::Worker.per_worker_stats = true
+    Resque.per_worker_stats = true
   end
 
   it "stats are erased when the worker goes away" do
@@ -570,13 +570,13 @@ describe "Resque::Worker" do
   end
 
   it "doesn't track start if disabled" do
-    Resque::Worker.track_starts = false
+    Resque.track_starts = false
       without_forking do
         @worker.extend(AssertInWorkBlock).work(0) do
           assert_nil @worker.started
         end
       end
-    Resque::Worker.track_starts = true
+    Resque.track_starts = true
   end
 
   it "knows whether it exists or not" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -1434,6 +1434,14 @@ describe "Resque::Worker with queues_in_names false" do
     assert_equal ["jobs"], loaded_queues
   end
 
+  it "loads queues for a worker with wildcards" do
+    splat_worker = Resque::Worker.new("*")
+    splat_worker.to_s = "bar:3:-"
+    splat_worker.register_worker
+
+    assert_equal ["*"], Resque.data_store.get_worker_queues(splat_worker)
+  end
+
   it "prunes dead workers with heartbeat older than prune interval" do
     assert_equal({}, Resque::Worker.all_heartbeats)
     now = Time.now


### PR DESCRIPTION
Incorporates the Github-specific changes into upstream. 

---
Based on: https://github.com/github/resque/pull/10 and https://github.com/github/resque/pull/11

To reduce Redis traffic, Github's fork of Redis drops some statistics tracking that isn't used there:

* `workers:$$:started` (set at worker start)
* `Stat["processed:$$"]` and `Stat["failed:$$"]` (per-worker job
counters)

This PR allows opting-out of collecting these statistics via flags on `Resque`:
```
Resque.track_starts = false # disables started key
Resque.per_worker_stats = false # disables fine-grained counts
```

Standard Resque workers store the list of queues they're listening to in their name; this can cause Redis performance issues with long queue lists. Setting `Resque.queues_in_names` to `false` makes workers keep the list in a separate Redis entry.

Blocking pops are always enabled; making them configurable would require some tricky refactoring in `work` since the stock `reserve` doesn't have the same sleeping behavior. Incorporates the fix from https://github.com/github/resque/pull/12

Adds the `before_reserve` callback; raising `Resque::Job::DontReserve` will skip checking that queue. See https://github.com/github/resque/pull/4 for more.

Adds the global `after_perform` callback. Will require a minor modification to `github/github`; the callback in that repo expects a worker but gets a job - should call `job.worker`.

Passes the worker to `before_first_fork` callbacks. See https://github.com/github/resque/pull/2 and https://github.com/github/github/pull/16141 for more details.
